### PR TITLE
feat(locales): add serbian latin and cyrillic support

### DIFF
--- a/docs/data/data-grid/localization/localization.md
+++ b/docs/data/data-grid/localization/localization.md
@@ -96,6 +96,17 @@ import { nlNL } from '@mui/x-data-grid/locales';
 <DataGrid localeText={nlNL.components.MuiDataGrid.defaultProps.localeText} />;
 ```
 
+### Serbian scripts
+
+Serbian translations are provided in both Latin (`srLatn`) and Cyrillic (`srRS`) scripts. Choose the desired locale when creating the theme or pass the locale text directly.
+
+```jsx
+import { srLatn, srRS } from '@mui/x-data-grid/locales';
+const theme = createTheme({}, useCyrillic ? srRS : srLatn);
+```
+
+To add another language or script, create a new locale file in the `locales` directory and export it from `index.ts`.
+
 ### Supported locales
 
 {{"demo": "DataGridLocalisationTableNoSnap.js", "hideToolbar": true, "bg": "inline"}}

--- a/docs/data/date-pickers/localization/localization.md
+++ b/docs/data/date-pickers/localization/localization.md
@@ -123,6 +123,18 @@ This will produce the following result:
 
 :::
 
+### Serbian scripts
+
+Date and Time Pickers also include Serbian translations in both Latin (`srLatn`) and Cyrillic (`srRS`) scripts.
+Toggle between them based on user preference:
+
+```jsx
+import { srLatn, srRS } from '@mui/x-date-pickers/locales';
+const theme = createTheme({}, useCyrillic ? srRS : srLatn);
+```
+
+You can create additional locales or script variations by adding new files under `packages/x-date-pickers/src/locales` and exporting them in `index.ts`.
+
 ## Supported locales
 
 {{"demo": "PickersLocalisationTableNoSnap.js", "hideToolbar": true, "bg": "inline"}}

--- a/packages/x-data-grid/src/locales/index.ts
+++ b/packages/x-data-grid/src/locales/index.ts
@@ -38,3 +38,5 @@ export * from './ptPT';
 export * from './zhHK';
 export * from './isIS';
 export * from './idID';
+export * from './srLatn';
+export * from './srRS';

--- a/packages/x-data-grid/src/locales/srLatn.ts
+++ b/packages/x-data-grid/src/locales/srLatn.ts
@@ -1,0 +1,316 @@
+import { GridLocaleText } from '../models/api/gridLocaleTextApi';
+import { getGridLocalization } from '../utils/getGridLocalization';
+
+const srLatnGrid: Partial<GridLocaleText> = {
+  // Root
+  noRowsLabel: 'Nema redova',
+  noResultsOverlayLabel: 'Nema rezultata.',
+  noColumnsOverlayLabel: 'Nema kolona',
+  noColumnsOverlayManageColumns: 'Upravljaj kolonama',
+  // emptyPivotOverlayLabel: 'Add fields to rows, columns, and values to create a pivot table',
+
+  // Density selector toolbar button text
+  toolbarDensity: 'Gustoća',
+  toolbarDensityLabel: 'Gustoća',
+  toolbarDensityCompact: 'Kompaktno',
+  toolbarDensityStandard: 'Standardno',
+  toolbarDensityComfortable: 'Udobno',
+
+  // Columns selector toolbar button text
+  toolbarColumns: 'Kolone',
+  toolbarColumnsLabel: 'Izaberite kolone',
+
+  // Filters toolbar button text
+  toolbarFilters: 'Filteri',
+  toolbarFiltersLabel: 'Prikaži filtere',
+  toolbarFiltersTooltipHide: 'Sakrij filtere',
+  toolbarFiltersTooltipShow: 'Prikaži filtere',
+  toolbarFiltersTooltipActive: (count) => {
+    if (count === 1) {
+      return `${count} aktivan filter`;
+    }
+    if (count < 5) {
+      return `${count} aktivna filtera`;
+    }
+    return `${count} aktivnih filtera`;
+  },
+
+  // Quick filter toolbar field
+  toolbarQuickFilterPlaceholder: 'Traži…',
+  toolbarQuickFilterLabel: 'traži',
+  toolbarQuickFilterDeleteIconLabel: 'Obriši',
+
+  // Export selector toolbar button text
+  toolbarExport: 'Izvoz',
+  toolbarExportLabel: 'Izvoz',
+  toolbarExportCSV: 'Preuzmi kao CSV',
+  toolbarExportPrint: 'Štampaj',
+  toolbarExportExcel: 'Preuzmi kao Excel',
+
+  // Toolbar pivot button
+  // toolbarPivot: 'Pivot',
+
+  // Toolbar AI Assistant button
+  toolbarAssistant: 'AI Asistent',
+
+  // Columns management text
+  columnsManagementSearchTitle: 'Pretraži',
+  columnsManagementNoColumns: 'Nema kolona',
+  columnsManagementShowHideAllText: 'Prikaži/Sakrij sve',
+  columnsManagementReset: 'Resetuj',
+  columnsManagementDeleteIconLabel: 'Obriši',
+
+  // Filter panel text
+  filterPanelAddFilter: 'Dodaj filter',
+  filterPanelRemoveAll: 'Ukloni sve',
+  filterPanelDeleteIconLabel: 'Obriši',
+  filterPanelLogicOperator: 'Logički operator',
+  filterPanelOperator: 'Operator',
+  filterPanelOperatorAnd: 'I',
+  filterPanelOperatorOr: 'Ili',
+  filterPanelColumns: 'Kolona',
+  filterPanelInputLabel: 'Vrednost',
+  filterPanelInputPlaceholder: 'Vrednost filtera',
+
+  // Filter operators text
+  filterOperatorContains: 'sadrži',
+  filterOperatorDoesNotContain: 'ne sadrži',
+  filterOperatorEquals: 'je jednak',
+  filterOperatorDoesNotEqual: 'nije jednak',
+  filterOperatorStartsWith: 'počinje sa',
+  filterOperatorEndsWith: 'završava sa',
+  filterOperatorIs: 'je',
+  filterOperatorNot: 'nije',
+  filterOperatorAfter: 'je posle',
+  filterOperatorOnOrAfter: 'je na ili posle',
+  filterOperatorBefore: 'je pre',
+  filterOperatorOnOrBefore: 'je na ili pre',
+  filterOperatorIsEmpty: 'je prazno',
+  filterOperatorIsNotEmpty: 'nije prazno',
+  filterOperatorIsAnyOf: 'je bilo koji od',
+  'filterOperator=': '=',
+  'filterOperator!=': '!=',
+  'filterOperator>': '>',
+  'filterOperator>=': '>=',
+  'filterOperator<': '<',
+  'filterOperator<=': '<=',
+
+  // Header filter operators text
+  headerFilterOperatorContains: 'Sadrži',
+  headerFilterOperatorDoesNotContain: 'Ne sadrži',
+  headerFilterOperatorEquals: 'Jednako',
+  headerFilterOperatorDoesNotEqual: 'Nije jednako',
+  headerFilterOperatorStartsWith: 'Počinje sa',
+  headerFilterOperatorEndsWith: 'Završava sa',
+  headerFilterOperatorIs: 'Je',
+  headerFilterOperatorNot: 'Nije',
+  headerFilterOperatorAfter: 'Je posle',
+  headerFilterOperatorOnOrAfter: 'Je uključeno ili posle',
+  headerFilterOperatorBefore: 'Je pre',
+  headerFilterOperatorOnOrBefore: 'Je uključeno ili pre',
+  headerFilterOperatorIsEmpty: 'Je prazno',
+  headerFilterOperatorIsNotEmpty: 'Nije prazno',
+  headerFilterOperatorIsAnyOf: 'Je bilo koji od',
+  'headerFilterOperator=': 'Jednako',
+  'headerFilterOperator!=': 'Nije jednako',
+  'headerFilterOperator>': 'Veći od',
+  'headerFilterOperator>=': 'Veće ili jednako',
+  'headerFilterOperator<': 'Manje od',
+  'headerFilterOperator<=': 'Manje od ili jednako',
+  headerFilterClear: 'Obriši filter',
+
+  // Filter values text
+  filterValueAny: 'bilo koji',
+  filterValueTrue: 'tačno',
+  filterValueFalse: 'netačno',
+
+  // Column menu text
+  columnMenuLabel: 'Meni',
+  columnMenuAriaLabel: (columnName: string) => `Meni kolona ${columnName}`,
+  columnMenuShowColumns: 'Prikaži kolone',
+  columnMenuManageColumns: 'Upravljanje kolonama',
+  columnMenuFilter: 'Filter',
+  columnMenuHideColumn: 'Sakrij kolonu',
+  columnMenuUnsort: 'Poništi sortiranje',
+  columnMenuSortAsc: 'Sortiraj uzlazno',
+  columnMenuSortDesc: 'Sortiraj silazno',
+  // columnMenuManagePivot: 'Manage pivot',
+
+  // Column header text
+  columnHeaderFiltersTooltipActive: (count) => {
+    if (count === 1) {
+      return `${count} aktivan filter`;
+    }
+    if (count < 5) {
+      return `${count} aktivna filtera`;
+    }
+    return `${count} aktivnih filtera`;
+  },
+  columnHeaderFiltersLabel: 'Prikaži filtere',
+  columnHeaderSortIconLabel: 'Sortiraj',
+
+  // Rows selected footer text
+  footerRowSelected: (count) => {
+    if (count === 1) {
+      return `Izabran je ${count.toLocaleString()} red`;
+    }
+    if (count < 5) {
+      return `Izabrana su ${count.toLocaleString()} reda`;
+    }
+    return `Izabrano je ${count.toLocaleString()} redova`;
+  },
+
+  // Total row amount footer text
+  footerTotalRows: 'Ukupno redova:',
+
+  // Total visible row amount footer text
+  footerTotalVisibleRows: (visibleCount, totalCount) =>
+    `${visibleCount.toLocaleString()} od ${totalCount.toLocaleString()}`,
+
+  // Checkbox selection text
+  checkboxSelectionHeaderName: 'Izbor redova',
+  checkboxSelectionSelectAllRows: 'Izaberite sve redove',
+  checkboxSelectionUnselectAllRows: 'Poništi izbor svih redova',
+  checkboxSelectionSelectRow: 'Izaberite red',
+  checkboxSelectionUnselectRow: 'Poništi izbor reda',
+
+  // Boolean cell text
+  booleanCellTrueLabel: 'Da',
+  booleanCellFalseLabel: 'Ne',
+
+  // Actions cell more text
+  actionsCellMore: 'više',
+
+  // Column pinning text
+  pinToLeft: 'Zakači levo',
+  pinToRight: 'Zakači desno',
+  unpin: 'Otkači',
+
+  // Tree Data
+  treeDataGroupingHeaderName: 'Grupa',
+  treeDataExpand: 'prikaži decu',
+  treeDataCollapse: 'sakrij decu',
+
+  // Grouping columns
+  groupingColumnHeaderName: 'Grupa',
+  groupColumn: (name) => `Grupiši po ${name}`,
+  unGroupColumn: (name) => `Prekini grupisanje po ${name}`,
+
+  // Master/detail
+  detailPanelToggle: 'Prebacivanje panela sa detaljima',
+  expandDetailPanel: 'Proširi',
+  collapseDetailPanel: 'Skupi',
+
+  // Pagination
+  paginationRowsPerPage: 'Redova po stranici:',
+  paginationDisplayedRows: ({ from, to, count, estimated }) => {
+    if (!estimated) {
+      return `${from}–${to} od ${count !== -1 ? count : `više nego ${to}`}`;
+    }
+    const estimatedLabel = estimated && estimated > to ? `oko ${estimated}` : `više nego ${to}`;
+    return `${from}–${to} od ${count !== -1 ? count : estimatedLabel}`;
+  },
+  paginationItemAriaLabel: (type) => {
+    if (type === 'first') {
+      return 'Idi na prvu stranicu';
+    }
+    if (type === 'last') {
+      return 'Idi na poslednju stranicu';
+    }
+    if (type === 'next') {
+      return 'Idi na sledeću stranicu';
+    }
+    // if (type === 'previous') {
+    return 'Idi na prethodnu stranicu';
+  },
+
+  // Row reordering text
+  rowReorderingHeaderName: 'Promena redosleda',
+
+  // Aggregation
+  aggregationMenuItemHeader: 'Agregacija',
+  aggregationFunctionLabelSum: 'iznos',
+  aggregationFunctionLabelAvg: 'pros',
+  aggregationFunctionLabelMin: 'min',
+  aggregationFunctionLabelMax: 'max',
+  aggregationFunctionLabelSize: 'veličina',
+
+  // Pivot panel
+  // pivotToggleLabel: 'Pivot',
+  // pivotRows: 'Rows',
+  // pivotColumns: 'Columns',
+  // pivotValues: 'Values',
+  // pivotCloseButton: 'Close pivot settings',
+  // pivotSearchButton: 'Search fields',
+  // pivotSearchControlPlaceholder: 'Search fields',
+  // pivotSearchControlLabel: 'Search fields',
+  // pivotSearchControlClear: 'Clear search',
+  // pivotNoFields: 'No fields',
+  // pivotMenuMoveUp: 'Move up',
+  // pivotMenuMoveDown: 'Move down',
+  // pivotMenuMoveToTop: 'Move to top',
+  // pivotMenuMoveToBottom: 'Move to bottom',
+  // pivotMenuRows: 'Rows',
+  // pivotMenuColumns: 'Columns',
+  // pivotMenuValues: 'Values',
+  // pivotMenuOptions: 'Field options',
+  // pivotMenuAddToRows: 'Add to Rows',
+  // pivotMenuAddToColumns: 'Add to Columns',
+  // pivotMenuAddToValues: 'Add to Values',
+  // pivotMenuRemove: 'Remove',
+  // pivotDragToRows: 'Drag here to create rows',
+  // pivotDragToColumns: 'Drag here to create columns',
+  // pivotDragToValues: 'Drag here to create values',
+  // pivotYearColumnHeaderName: '(Year)',
+  // pivotQuarterColumnHeaderName: '(Quarter)',
+
+  // AI Assistant panel
+  aiAssistantPanelTitle: 'AI Asistent',
+  // aiAssistantPanelClose: 'Close AI Assistant',
+  // aiAssistantPanelNewConversation: 'New conversation',
+  // aiAssistantPanelConversationHistory: 'Conversation history',
+  // aiAssistantPanelEmptyConversation: 'No prompt history',
+  aiAssistantSuggestions: 'Predlozi',
+
+  // Prompt field
+  promptFieldLabel: 'Upit',
+  promptFieldPlaceholder: 'Unesi upit…',
+  promptFieldPlaceholderWithRecording: 'Unesi ili snimi upit…',
+  promptFieldPlaceholderListening: 'Slušam upit…',
+  promptFieldSpeechRecognitionNotSupported: 'Prepoznavanje govora nije podržano u ovom pregledaču',
+  promptFieldSend: 'Pošalji',
+  promptFieldRecord: 'Snimi',
+  promptFieldStopRecording: 'Zaustavi snimanje',
+
+  // Prompt
+  promptRerun: 'Probaj ponovo',
+  // promptProcessing: 'Processing…',
+  // promptAppliedChanges: 'Applied changes',
+
+  // Prompt changes
+  // promptChangeGroupDescription: (column: string) => `Group by ${column}`,
+  // promptChangeAggregationLabel: (column: string, aggregation: string) => `${column} (${aggregation})`,
+  // promptChangeAggregationDescription: (column: string, aggregation: string) => `Aggregate ${column} (${aggregation})`,
+  // promptChangeFilterLabel: (column: string, operator: string, value: string) => {
+  //   if (operator === 'is any of') {
+  //     return `${column} is any of: ${value}`;
+  //   }
+  //   return `${column} ${operator} ${value}`;
+  // },
+  // promptChangeFilterDescription: (column: string, operator: string, value: string) => {
+  //   if (operator === 'is any of') {
+  //     return `Filter where ${column} is any of: ${value}`;
+  //   }
+  //   return `Filter where ${column} ${operator} ${value}`;
+  // },
+  // promptChangeSortDescription: (column: string, direction: string) => `Sort by ${column} (${direction})`,
+  // promptChangePivotEnableLabel: 'Pivot',
+  // promptChangePivotEnableDescription: 'Enable pivot',
+  // promptChangePivotColumnsLabel: (count: number) => `Columns (${count})`,
+  // promptChangePivotColumnsDescription: (column: string, direction: string) => `${column}${direction ? ` (${direction})` : ''}`,
+  // promptChangePivotRowsLabel: (count: number) => `Rows (${count})`,
+  // promptChangePivotValuesLabel: (count: number) => `Values (${count})`,
+  // promptChangePivotValuesDescription: (column: string, aggregation: string) => `${column} (${aggregation})`,
+};
+
+export const srLatn = getGridLocalization(srLatnGrid);

--- a/packages/x-data-grid/src/locales/srRS.ts
+++ b/packages/x-data-grid/src/locales/srRS.ts
@@ -1,0 +1,44 @@
+import { Localization } from '../utils/getGridLocalization';
+import { srLatn } from './srLatn';
+
+function toCyrillic(value: string): string {
+  const map: Record<string, string> = {
+    dj: 'ђ', Dj: 'Ђ', Dž: 'Џ', dž: 'џ', LJ: 'Љ', Lj: 'Љ', lj: 'љ', NJ: 'Њ', Nj: 'Њ', nj: 'њ',
+    A: 'А', a: 'а', B: 'Б', b: 'б', V: 'В', v: 'в', G: 'Г', g: 'г', D: 'Д', d: 'д', Đ: 'Ђ', đ: 'ђ',
+    E: 'Е', e: 'е', Ž: 'Ж', ž: 'ж', Z: 'З', z: 'з', I: 'И', i: 'и', J: 'Ј', j: 'ј', K: 'К', k: 'к',
+    L: 'Л', l: 'л', M: 'М', m: 'м', N: 'Н', n: 'н', O: 'О', o: 'о', P: 'П', p: 'п', R: 'Р', r: 'р',
+    S: 'С', s: 'с', T: 'Т', t: 'т', Ć: 'Ћ', ć: 'ћ', U: 'У', u: 'у', F: 'Ф', f: 'ф', H: 'Х', h: 'х',
+    C: 'Ц', c: 'ц', Č: 'Ч', č: 'ч', Š: 'Ш', š: 'ш', Y: 'Ј', y: 'ј', X: 'Кс', x: 'кс', W: 'В', w: 'в',
+    Q: 'К', q: 'к'
+  };
+  return value
+    .replace(/dž|Dž|DŽ|nj|Nj|NJ|lj|Lj|LJ/g, (m) => map[m])
+    .split('')
+    .map((ch) => map[ch] || ch)
+    .join('');
+}
+
+function convert(obj: any): any {
+  if (typeof obj === 'string') {
+    return toCyrillic(obj);
+  }
+  if (typeof obj === 'function') {
+    return (...args: any[]) => {
+      const result = obj(...args);
+      return typeof result === 'string' ? toCyrillic(result) : result;
+    };
+  }
+  if (Array.isArray(obj)) {
+    return obj.map(convert);
+  }
+  if (obj && typeof obj === 'object') {
+    const out: Record<string, any> = {};
+    Object.keys(obj).forEach((key) => {
+      out[key] = convert(obj[key]);
+    });
+    return out;
+  }
+  return obj;
+}
+
+export const srRS: Localization = convert(srLatn);

--- a/packages/x-date-pickers/src/locales/index.ts
+++ b/packages/x-date-pickers/src/locales/index.ts
@@ -39,3 +39,5 @@ export * from './zhCN';
 export * from './zhHK';
 export * from './zhTW';
 export * from './utils/pickersLocaleTextApi';
+export * from './srLatn';
+export * from './srRS';

--- a/packages/x-date-pickers/src/locales/srLatn.ts
+++ b/packages/x-date-pickers/src/locales/srLatn.ts
@@ -1,0 +1,117 @@
+import { PickersLocaleText } from './utils/pickersLocaleTextApi';
+import { getPickersLocalization } from './utils/getPickersLocalization';
+import { TimeViewWithMeridiem } from '../internals/models';
+
+// maps TimeView to its translation
+const timeViews: Record<TimeViewWithMeridiem, string> = {
+  hours: 'sati',
+  minutes: 'minute',
+  seconds: 'sekunde',
+  meridiem: 'meridiem',
+};
+
+const srLatnPickers: Partial<PickersLocaleText> = {
+  // Calendar navigation
+  previousMonth: 'Prethodni mesec',
+  nextMonth: 'Sledeći mesec',
+
+  // View navigation
+  openPreviousView: 'Otvori prethodni prikaz',
+  openNextView: 'Otvori sledeći prikaz',
+  calendarViewSwitchingButtonAriaLabel: (view) =>
+    view === 'year'
+      ? 'Otvoren je godišnji prikaz, promeni na kalendarski prikaz'
+      : 'Otvoren je kalendarski prikaz, promeni na godišnji prikaz',
+
+  // DateRange labels
+  start: 'Početak',
+  end: 'Kraj',
+  startDate: 'Početni datum',
+  startTime: 'Početno vreme',
+  endDate: 'Krajnji datum',
+  endTime: 'Krajnje vreme',
+
+  // Action bar
+  cancelButtonLabel: 'Otkaži',
+  clearButtonLabel: 'Obriši',
+  okButtonLabel: 'U redu',
+  todayButtonLabel: 'Danas',
+  nextStepButtonLabel: 'Sledeći',
+
+  // Toolbar titles
+  datePickerToolbarTitle: 'Izaberi datum',
+  dateTimePickerToolbarTitle: 'Izaberi datum i vreme',
+  timePickerToolbarTitle: 'Izaberi vreme',
+  dateRangePickerToolbarTitle: 'Izaberi vremenski opseg',
+  // timeRangePickerToolbarTitle: 'Select time range',
+
+  // Clock labels
+  clockLabelText: (view, formattedTime) =>
+    `Izaberi ${timeViews[view] ?? view}. ${!formattedTime ? 'Vreme nije izabrano' : `Izabrano vreme je ${formattedTime}`}`,
+  hoursClockNumberText: (hours) => {
+    let suffix = 'sati';
+    if (Number(hours) === 1) {
+      suffix = 'sat';
+    } else if (Number(hours) < 5) {
+      suffix = 'sata';
+    }
+    return `${hours} ${suffix}`;
+  },
+  minutesClockNumberText: (minutes) =>
+    `${minutes} ${Number(minutes) > 1 && Number(minutes) < 5 ? 'minute' : 'minuta'}`,
+  secondsClockNumberText: (seconds) => {
+    let suffix = 'sekundi';
+    if (Number(seconds) === 1) {
+      suffix = 'sekunda';
+    } else if (Number(seconds) < 5) {
+      suffix = 'sekunde';
+    }
+    return `${seconds} ${suffix}`;
+  },
+
+  // Digital clock labels
+  selectViewText: (view) => `Izaberi ${timeViews[view]}`,
+
+  // Calendar labels
+  calendarWeekNumberHeaderLabel: 'Broj nedelje',
+  calendarWeekNumberHeaderText: '#',
+  calendarWeekNumberAriaLabelText: (weekNumber) => `Nedelja ${weekNumber}`,
+  calendarWeekNumberText: (weekNumber) => `${weekNumber}`,
+
+  // Open Picker labels
+  openDatePickerDialogue: (formattedDate) =>
+    formattedDate ? `Izaberi datum, izabrani datum je ${formattedDate}` : 'Izaberi datum',
+  openTimePickerDialogue: (formattedTime) =>
+    formattedTime ? `Izaberi vreme, izabrano vreme je ${formattedTime}` : 'Izaberi vreme',
+  // openRangePickerDialogue: formattedRange => formattedRange ? `Choose range, selected range is ${formattedRange}` : 'Choose range',
+  fieldClearLabel: 'Obriši',
+
+  // Table labels
+  timeTableLabel: 'Izaberi vreme',
+  dateTableLabel: 'Izaberi datum',
+
+  // Field section placeholders
+  fieldYearPlaceholder: (params) => 'G'.repeat(params.digitAmount),
+  fieldMonthPlaceholder: (params) => (params.contentType === 'letter' ? 'MMMM' : 'MM'),
+  fieldDayPlaceholder: () => 'DD',
+  fieldWeekDayPlaceholder: (params) => (params.contentType === 'letter' ? 'EEEE' : 'EE'),
+  fieldHoursPlaceholder: () => 'hh',
+  fieldMinutesPlaceholder: () => 'mm',
+  fieldSecondsPlaceholder: () => 'ss',
+  fieldMeridiemPlaceholder: () => 'aa',
+
+  // View names
+  year: 'Godina',
+  month: 'Mesec',
+  day: 'Dan',
+  weekDay: 'Dan u nedelji',
+  hours: 'Sati',
+  minutes: 'Minute',
+  seconds: 'Sekunde',
+  meridiem: 'Meridiem',
+
+  // Common
+  empty: 'Isprazni',
+};
+
+export const srLatn = getPickersLocalization(srLatnPickers);

--- a/packages/x-date-pickers/src/locales/srRS.ts
+++ b/packages/x-date-pickers/src/locales/srRS.ts
@@ -1,0 +1,44 @@
+import { PickersLocaleText } from './utils/pickersLocaleTextApi';
+import { srLatn } from './srLatn';
+
+function toCyrillic(value: string): string {
+  const map: Record<string, string> = {
+    dj: 'ђ', Dj: 'Ђ', Dž: 'Џ', dž: 'џ', LJ: 'Љ', Lj: 'Љ', lj: 'љ', NJ: 'Њ', Nj: 'Њ', nj: 'њ',
+    A: 'А', a: 'а', B: 'Б', b: 'б', V: 'В', v: 'в', G: 'Г', g: 'г', D: 'Д', d: 'д', Đ: 'Ђ', đ: 'ђ',
+    E: 'Е', e: 'е', Ž: 'Ж', ž: 'ж', Z: 'З', z: 'з', I: 'И', i: 'и', J: 'Ј', j: 'ј', K: 'К', k: 'к',
+    L: 'Л', l: 'л', M: 'М', m: 'м', N: 'Н', n: 'н', O: 'О', o: 'о', P: 'П', p: 'п', R: 'Р', r: 'р',
+    S: 'С', s: 'с', T: 'Т', t: 'т', Ć: 'Ћ', ć: 'ћ', U: 'У', u: 'у', F: 'Ф', f: 'ф', H: 'Х', h: 'х',
+    C: 'Ц', c: 'ц', Č: 'Ч', č: 'ч', Š: 'Ш', š: 'ш', Y: 'Ј', y: 'ј', X: 'Кс', x: 'кс', W: 'В', w: 'в',
+    Q: 'К', q: 'к'
+  };
+  return value
+    .replace(/dž|Dž|DŽ|nj|Nj|NJ|lj|Lj|LJ/g, (m) => map[m])
+    .split('')
+    .map((ch) => map[ch] || ch)
+    .join('');
+}
+
+function convert(obj: any): any {
+  if (typeof obj === 'string') {
+    return toCyrillic(obj);
+  }
+  if (typeof obj === 'function') {
+    return (...args: any[]) => {
+      const result = obj(...args);
+      return typeof result === 'string' ? toCyrillic(result) : result;
+    };
+  }
+  if (Array.isArray(obj)) {
+    return obj.map(convert);
+  }
+  if (obj && typeof obj === 'object') {
+    const out: Record<string, any> = {};
+    Object.keys(obj).forEach((key) => {
+      out[key] = convert(obj[key]);
+    });
+    return out;
+  }
+  return obj;
+}
+
+export const srRS: PickersLocaleText = convert(srLatn) as PickersLocaleText;


### PR DESCRIPTION
## Summary
- add Serbian Latin and Cyrillic locale files for Data Grid and Date Pickers
- document how to switch between Serbian scripts and add future locale guidance

## Testing
- `pnpm test` *(fails: cross-env not found)*
- `pnpm install` *(fails: 403 fetching @vvago/vale)*

------
https://chatgpt.com/codex/tasks/task_e_68915b79dc648320aa003313596b3365