### PR TITLE
docs: remove Serbian script note

### DIFF
--- a/docs/data/data-grid/localization/localization.md
+++ b/docs/data/data-grid/localization/localization.md
@@ -96,17 +96,6 @@ import { nlNL } from '@mui/x-data-grid/locales';
 <DataGrid localeText={nlNL.components.MuiDataGrid.defaultProps.localeText} />;
 ```
 
-### Serbian scripts
-
-Serbian translations are provided in both Latin (`srLatn`) and Cyrillic (`srRS`) scripts. Choose the desired locale when creating the theme or pass the locale text directly.
-
-```jsx
-import { srLatn, srRS } from '@mui/x-data-grid/locales';
-const theme = createTheme({}, useCyrillic ? srRS : srLatn);
-```
-
-To add another language or script, create a new locale file in the `locales` directory and export it from `index.ts`.
-
 ### Supported locales
 
 {{"demo": "DataGridLocalisationTableNoSnap.js", "hideToolbar": true, "bg": "inline"}}

--- a/docs/data/date-pickers/localization/localization.md
+++ b/docs/data/date-pickers/localization/localization.md
@@ -123,18 +123,6 @@ This will produce the following result:
 
 :::
 
-### Serbian scripts
-
-Date and Time Pickers also include Serbian translations in both Latin (`srLatn`) and Cyrillic (`srRS`) scripts.
-Toggle between them based on user preference:
-
-```jsx
-import { srLatn, srRS } from '@mui/x-date-pickers/locales';
-const theme = createTheme({}, useCyrillic ? srRS : srLatn);
-```
-
-You can create additional locales or script variations by adding new files under `packages/x-date-pickers/src/locales` and exporting them in `index.ts`.
-
 ## Supported locales
 
 {{"demo": "PickersLocalisationTableNoSnap.js", "hideToolbar": true, "bg": "inline"}}


### PR DESCRIPTION
## Summary
- remove Serbian script snippet from Data Grid localization docs
- remove Serbian script snippet from Date and Time Pickers localization docs

## Testing
- `node node_modules/tsx/dist/cli.mjs ./scripts/buildApiDocs/index.ts`
- `node node_modules/tsx/dist/cli.mjs ./docs/scripts/api/buildApi.ts`
- `node node_modules/pretty-quick/lib/cli.mjs --ignore-path .lintignore --branch master`


------
https://chatgpt.com/codex/tasks/task_e_689240e7db848320943274c3d68d4264